### PR TITLE
build(anemui-core): harden webpack resolution for monorepo

### DIFF
--- a/anemui-core/webpack.config.js
+++ b/anemui-core/webpack.config.js
@@ -75,20 +75,34 @@ const base={
     path:moduleConfig.distPath,
   },
   resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    modules: [
+      path.resolve(__dirname, 'node_modules'),
+      'node_modules',
+    ],
+    alias: {
+      'tsx-create-element': require.resolve('tsx-create-element')
+    },
     fallback: {
-      buffer: require.resolve('buffer'),
+      buffer: require.resolve('buffer/'),
     }
+  },
+  resolveLoader: {
+    modules: [
+      path.resolve(__dirname, 'node_modules'),
+      'node_modules',
+    ]
   },
   module: {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'ts-loader',
+        loader: require.resolve('ts-loader'),
         options: { allowTsInNodeModules: true }
       },
       {
         test: /\.css$/i,
-        use: [miniCssExtractPlugin.loader, 'css-loader'],
+        use: [miniCssExtractPlugin.loader, require.resolve('css-loader')],
         //type: 'asset/resource',
       },
       {
@@ -105,21 +119,19 @@ const base={
             loader: miniCssExtractPlugin.loader
           },
           {
-            loader: 'css-loader'
+            loader: require.resolve('css-loader')
           },
           {
-            loader: 'postcss-loader',
+            loader: require.resolve('postcss-loader'),
           },
           {
-            loader: 'sass-loader'
+            loader: require.resolve('sass-loader')
           }
         ]
       }
     ],
   },
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
+  // resolve merged into single definition above
   plugins: [
     new webpack.DefinePlugin({
       'process.env.ENV':JSON.stringify(ENV),


### PR DESCRIPTION
- Add resolve.modules to include anemui-core/node_modules and node_modules
- Add resolveLoader.modules to prefer local core loaders and fall back to hoisted root
- Use require.resolve for ts/css/postcss/sass loaders to avoid Module is not a loader and ensure absolute paths
- Add alias for tsx-create-element
- Use proper Buffer fallback via buffer/
- Merge duplicate resolve blocks into a single definition

Result: stable loader/module resolution when running from the monorepo root without nested node_modules.