### PR TITLE
Ccm

### DIFF
--- a/anemui-core/src/OpenLayersMap.ts
+++ b/anemui-core/src/OpenLayersMap.ts
@@ -1139,24 +1139,30 @@ async updateRender(support: string): Promise<void> {
     const currentCenter = this.map.getView().getCenter();
     const currentResolution = this.map.getView().getResolution();
 
-    // Paso 1: Capturar Península + Baleares
-    // Padding asimétrico: [top, right, bottom, left] - más a la izquierda para dejar espacio al recuadro de Canarias
-    const peninsulaExtent4326 = [-10.0, 35.0, 5.0, 44.5];
-    const peninsulaExtent = transformExtent(peninsulaExtent4326, 'EPSG:4326', proj);
-    const mapSize0 = this.map.getSize();
-    const insetLeftPad = mapSize0 ? Math.round(mapSize0[0] * 0.22) : 200;
-    this.map.getView().fit(peninsulaExtent, { padding: [10, 35, 10, insetLeftPad] });
+    // Promesa que espera rendercomplete de forma fiable
+    const waitForRender = (): Promise<void> => {
+      return new Promise<void>((resolve) => {
+        this.map.once('rendercomplete', () => resolve());
+        this.map.renderSync();
+      });
+    };
 
-    this.map.once('rendercomplete', () => {
+    const doExport = async () => {
+      // Paso 1: Capturar Península + Baleares
+      const peninsulaExtent4326 = [-10.0, 35.0, 5.0, 44.5];
+      const peninsulaExtent = transformExtent(peninsulaExtent4326, 'EPSG:4326', proj);
+      const mapSize0 = this.map.getSize();
+      const insetLeftPad = mapSize0 ? Math.round(mapSize0[0] * 0.22) : 200;
+      this.map.getView().fit(peninsulaExtent, { padding: [10, 35, 10, insetLeftPad] });
+
+      await waitForRender();
+
       const mapSize = this.map.getSize();
       if (!mapSize) return;
       const mainWidth = mapSize[0];
       const mainHeight = mapSize[1];
 
-      // Capturar canvas OL de la península
       const mainOlCanvas = this.captureOlCanvas(mainWidth, mainHeight);
-
-      // Obtener bbox para WMS de la península
       const mainViewExtent = this.map.getView().calculateExtent(mapSize);
       const mainBbox4326 = transformExtent(mainViewExtent, proj, 'EPSG:4326');
 
@@ -1165,36 +1171,31 @@ async updateRender(support: string): Promise<void> {
       const canariasExtent = transformExtent(canariasExtent4326, 'EPSG:4326', proj);
       this.map.getView().fit(canariasExtent, { padding: [5, 5, 5, 5] });
 
-      this.map.once('rendercomplete', () => {
-        // Capturar canvas OL de Canarias
-        const insetWidth = Math.round(mainWidth * 0.30);
-        const insetHeight = Math.round(mainHeight * 0.28);
-        const canariasOlCanvas = this.captureOlCanvas(mapSize[0], mapSize[1]);
+      await waitForRender();
 
-        // Obtener bbox para WMS de Canarias
-        const canariasViewExtent = this.map.getView().calculateExtent(mapSize);
-        const canariasBbox4326 = transformExtent(canariasViewExtent, proj, 'EPSG:4326');
+      const insetWidth = Math.round(mainWidth * 0.30);
+      const insetHeight = Math.round(mainHeight * 0.28);
+      const canariasOlCanvas = this.captureOlCanvas(mapSize[0], mapSize[1]);
+      const canariasViewExtent = this.map.getView().calculateExtent(mapSize);
+      const canariasBbox4326 = transformExtent(canariasViewExtent, proj, 'EPSG:4326');
 
-        // Restaurar vista original
-        this.map.getView().setCenter(currentCenter);
-        this.map.getView().setResolution(currentResolution);
+      // Restaurar vista original
+      this.map.getView().setCenter(currentCenter);
+      this.map.getView().setResolution(currentResolution);
 
-        // Paso 3: Pedir ambas imágenes WMS al IGN y componer
-        this.loadWmsImages(mainBbox4326, mainWidth, mainHeight, canariasBbox4326, insetWidth, insetHeight,
-          (mainBg, canBg) => {
-            this.composeExportImage(
-              mainBg, mainOlCanvas, mainWidth, mainHeight,
-              canBg, canariasOlCanvas, insetWidth, insetHeight,
-              state, timesJs, app
-            );
-          }
-        );
-      });
+      // Paso 3: Pedir ambas imágenes WMS al IGN y componer
+      this.loadWmsImages(mainBbox4326, mainWidth, mainHeight, canariasBbox4326, insetWidth, insetHeight,
+        (mainBg, canBg) => {
+          this.composeExportImage(
+            mainBg, mainOlCanvas, mainWidth, mainHeight,
+            canBg, canariasOlCanvas, insetWidth, insetHeight,
+            state, timesJs, app
+          );
+        }
+      );
+    };
 
-      this.map.renderSync();
-    });
-
-    this.map.renderSync();
+    doExport();
   }
 
   private captureOlCanvas(width: number, height: number): HTMLCanvasElement {

--- a/anemui-core/src/PaletteManager.ts
+++ b/anemui-core/src/PaletteManager.ts
@@ -607,6 +607,13 @@ export class PaletteManager {
         return this.painter;
     }
 
+    /**
+     * Obtiene el painter registrado para un nombre de paleta específico
+     */
+    public getNamedPainter(name: string): Painter | undefined {
+        return this.painters[name];
+    }
+
     public getTransparency():number{
         return this.transparency;
     }

--- a/anemui-core/src/data/ChunkDownloader.ts
+++ b/anemui-core/src/data/ChunkDownloader.ts
@@ -95,6 +95,12 @@ async function rangeRequest(url: string, startByte: bigint, endByte: bigint): Pr
         const response = await fetch(url, { headers: headers });
         if (response.status === 206) {
             return new Uint8Array(await response.arrayBuffer());
+        } else if (response.status === 200) {
+            // Server doesn't support Range requests, extract the needed slice
+            const fullBuffer = await response.arrayBuffer();
+            const start = Number(startByte);
+            const end = Number(endByte) + 1; // endByte is inclusive in Range header
+            return new Uint8Array(fullBuffer.slice(start, end));
         } else if (response.status === 416) {
             console.error(`Range not satisfiable: requested bytes ${startByte}-${endByte} from ${url}`);
             throw new Error(`Range not satisfiable: requested bytes ${startByte}-${endByte} from ${url}`);
@@ -302,11 +308,6 @@ export async function buildImages(promises: Promise<number[]>[], dataTilesLayer:
         if (!uncertaintyLayer) {
             // Copia profunda para evitar problemas con referencias
             mainLayerData = filteredArrays.map(arr => [...arr]);
-            console.log('[buildImages] Guardando mainLayerData para máscara:', {
-                numPortions: mainLayerData.length,
-                lengths: mainLayerData.map(arr => arr.length),
-                nanCounts: mainLayerData.map(arr => arr.filter(v => isNaN(v) || !isFinite(v)).length)
-            });
         }
 
         let minArray: number = Number.MAX_VALUE;
@@ -382,9 +383,9 @@ export async function buildImages(promises: Promise<number[]>[], dataTilesLayer:
         if (uncertaintyLayer) {
             const overlayVarId = status.overlayVarId || '';
             const painterKey = overlayVarId.includes('_pvalue') ? 'significance' : 'uncertainty';
-            painterInstance = PaletteManager.getInstance()['painters'][painterKey]
-                || PaletteManager.getInstance()['painters']['uncertainty']
-                || PaletteManager.getInstance().getPainter();
+            painterInstance = PaletteManager.getInstance().getNamedPainter(painterKey)
+                || PaletteManager.getInstance().getNamedPainter('uncertainty')
+                || PaletteManager.getInstance().getPainter(true);
         } else {
             painterInstance = PaletteManager.getInstance().getPainter();
         }
@@ -405,25 +406,14 @@ export async function buildImages(promises: Promise<number[]>[], dataTilesLayer:
 
             // Para capa de incertidumbre, filtrar píxeles donde la capa principal es NaN (mar/otros países)
             if (uncertaintyLayer) {
-                console.log(`[buildImages] Incertidumbre porción ${i}:`, {
-                    mainLayerDataExists: !!mainLayerData[i],
-                    mainLayerLength: mainLayerData[i]?.length || 0,
-                    filteredArrayLength: filteredArray.length,
-                    lengthsMatch: mainLayerData[i]?.length === filteredArray.length
-                });
-
                 if (mainLayerData[i] && mainLayerData[i].length === filteredArray.length) {
-                    let maskedCount = 0;
                     filteredArray = filteredArray.map((val, idx) => {
                         const mainVal = mainLayerData[i][idx];
-                        // Si el dato principal es NaN, poner 0 en incertidumbre (no mostrar)
                         if (isNaN(mainVal) || !isFinite(mainVal)) {
-                            maskedCount++;
                             return 0;
                         }
                         return val;
                     });
-                    console.log(`[buildImages] Incertidumbre porción ${i}: ${maskedCount} píxeles enmascarados de ${filteredArray.length}`);
                 } else {
                     console.warn(`[buildImages] No se puede aplicar máscara en porción ${i}: mainLayerData no disponible o longitudes no coinciden`);
                 }
@@ -573,23 +563,6 @@ async function downloadXYChunkNC(t: number, varName: string, portion: string, ti
         if (!Array.isArray(floatArray) || floatArray.length === 0) {
             throw new Error(`Invalid float array: length=${floatArray.length}, isArray=${Array.isArray(floatArray)}`);
         }
-
-        const validValues = floatArray.filter(v => !isNaN(v) && isFinite(v));
-        const validCount = validValues.length;
-        // Usar reduce en vez de spread para evitar stack overflow en arrays grandes
-        const minVal = validValues.reduce((a, b) => Math.min(a, b), Infinity);
-        const maxVal = validValues.reduce((a, b) => Math.max(a, b), -Infinity);
-        console.log('🔍 downloadXYChunkNC OUTPUT:', {
-            varName,
-            portion,
-            actualTimeIndex,
-            total: floatArray.length,
-            valid: validCount,
-            validPercent: (validCount / floatArray.length * 100).toFixed(2) + '%',
-            samples: floatArray.slice(0, 20),
-            min: minVal,
-            max: maxVal
-        });
 
         xyCache = { t: actualTimeIndex, varName, portion, data: [...floatArray] };
 
@@ -804,11 +777,6 @@ export function downloadXYbyRegion(time: string, timeIndex: number, folder: stri
                     columns: true,
                     skip_empty_lines: true
                 });
-                console.log(`[downloadXYbyRegion] varName="${varName}", timeIndex=${timeIndex}, records.length=${records.length}`);
-                console.log(`[downloadXYbyRegion] records[${timeIndex}]['times_mean'] =`, records[timeIndex] ? records[timeIndex]['times_mean'] : 'undefined');
-                if (varName.includes('beta_b0') && records[timeIndex]) {
-                    console.log(`[downloadXYbyRegion] beta_b0 for province '1' (Araba):`, records[timeIndex]['1']);
-                }
                 stResult = records[timeIndex]
                 // if (records.length == 1) stResult = records[0];
                 // else {
@@ -841,8 +809,6 @@ export function downloadXYbyRegionMultiPortion(
     const promises = portions.map(portion => {
         return new Promise((resolve, reject) => {
             const csvPath = `./regData/${folder}/${varName}${portion}.csv`;
-            console.log("  📥 Downloading:", csvPath);
-            
             downloadUrl(csvPath, (status: number, response) => {
                 if (status == 200) {
                     try {


### PR DESCRIPTION
**1. PaletteManager.ts**
  - Nuevo método público getNamedPainter(name): Devuelve el painter registrado para un nombre de paleta específico. Evita acceder al campo protegido   
  painters con ['painters'] desde fuera de la clase.

  **2. ChunkDownloader.ts**

  - Fallback para servidores sin soporte Range: Cuando el servidor responde 200 en vez de 206, descarga el fichero completo y extrae el slice de bytes 
  necesario (antes lanzaba error).
  - Uso de getNamedPainter(): Reemplaza los accesos hacky PaletteManager.getInstance()['painters'][key] por la API pública getNamedPainter().
  - Eliminación de console.log de debug: Eliminados 8 logs de depuración. Se mantienen los console.error y console.warn.
  - Eliminación de variables no usadas: validValues, validCount, minVal, maxVal que solo servían para el log eliminado.

  **3. OpenLayersMap.ts**

  - exportMap() reescrito con async/await: Sustituye los callbacks anidados map.once('rendercomplete', ...) por una función waitForRender() basada en  Promise + async/await. Esto corrige la condición de carrera que causaba que la península y Canarias se intercambiaran en la imagen exportada.    